### PR TITLE
Postcode

### DIFF
--- a/lib/parkinsons_and_me/services_data.ex
+++ b/lib/parkinsons_and_me/services_data.ex
@@ -47,7 +47,8 @@ defmodule ParkinsonsAndMe.ServicesData do
       title: "Get in touch with a Parkinson’s nurse",
       body: "<p>Parkinson's nurses have specialist knowledge about Parkinson’s. They provide expert care to help you manage your medication and support you in coming to terms with your diagnosis. They can also make a referral for you to see another health professional if you need to, such as a physiotherapist.</p><p>To see a Parkinson’s nurse you will need a referral, <a href='https://www.parkinsons.org.uk/information-and-support/parkinsons-nurses' target='_blank'>here’s a bit more information one how to get one.</a></p>",
       cta: "Find your nearest Parkinson’s nurse",
-      url: "https://www.parkinsons.org.uk/local-support?op=Search&distance%5Bpostal_code%5D="
+      url: "https://www.parkinsons.org.uk/local-support?op=Search&distance%5Bpostal_code%5D=",
+      location_based_url: true
     }
   end
 
@@ -56,7 +57,8 @@ defmodule ParkinsonsAndMe.ServicesData do
       title: "Meet up with your local group",
       body: "<p>Going along to your local group gives you the chance to share experiences and discuss any worries with other people affected by Parkinson’s. Groups offer information, friendship and support, and many hold social activities.</p>",
       cta: "Find a local group in your area",
-      url: "https://www.parkinsons.org.uk/local-support?op=Search&distance%5Bpostal_code%5D="
+      url: "https://www.parkinsons.org.uk/local-support?op=Search&distance%5Bpostal_code%5D=",
+      location_based_url: true
     }
   end
 
@@ -74,7 +76,8 @@ defmodule ParkinsonsAndMe.ServicesData do
       title: "Meet your Parkinson’s local adviser",
       body: "<p>Our UK-wide network of friendly local advisers have a broad range of expertise about Parkinson's. You can meet up face-to-face or chat over the phone. Local advisers can help you navigate benefits and grants, give you tips on how to deal with the day-to-day impact of Parkinson’s, or just be there to offer some emotional support.</p>",
       cta: "Find out how to get in touch with your local adviser",
-      url: "https://www.parkinsons.org.uk/local-support?op=Search&distance%5Bpostal_code%5D="
+      url: "https://www.parkinsons.org.uk/local-support?op=Search&distance%5Bpostal_code%5D=",
+      location_based_url: true
     }
   end
 

--- a/priv/repo/migrations/20170509144349_potscode_url.exs
+++ b/priv/repo/migrations/20170509144349_potscode_url.exs
@@ -1,0 +1,15 @@
+defmodule ParkinsonsAndMe.Repo.Migrations.PotscodeUrl do
+  use Ecto.Migration
+
+  def up do
+    alter table(:services) do
+      add :location_based_url, :boolean, default: false
+    end
+  end
+
+  def down do
+    alter table(:services) do
+      remove :location_based_url
+    end
+  end
+end

--- a/test/elm/TestHelpers.elm
+++ b/test/elm/TestHelpers.elm
@@ -18,6 +18,7 @@ dummyServiceData =
     , cta = ""
     , url = ""
     , earlyOnset = False
+    , locationBasedUrl = False
     }
 
 

--- a/web/elm/Components/Utils.elm
+++ b/web/elm/Components/Utils.elm
@@ -11,6 +11,6 @@ emptyDiv =
     div [] []
 
 
-outboundLink : String -> String -> Html Msg
-outboundLink body url =
-    a [ href url, onClick <| TrackOutboundLink url ] [ text body ]
+outboundLink : String -> Html Msg -> Html Msg
+outboundLink url body =
+    a [ href url, onClick <| TrackOutboundLink url ] [ body ]

--- a/web/elm/Data/Services.elm
+++ b/web/elm/Data/Services.elm
@@ -38,4 +38,5 @@ nullServiceData =
     , cta = ""
     , url = ""
     , earlyOnset = False
+    , locationBasedUrl = False
     }

--- a/web/elm/Model.elm
+++ b/web/elm/Model.elm
@@ -81,6 +81,7 @@ type alias ServiceData =
     , cta : String
     , url : String
     , earlyOnset : Bool
+    , locationBasedUrl : Bool
     }
 
 
@@ -141,7 +142,11 @@ type alias QuoteServiceWeightings =
 
 type EntryPoint
     = Start
-    | Finish String
+    | Finish AnswerUuid
+
+
+type alias AnswerUuid =
+    String
 
 
 type Msg

--- a/web/elm/Views/Services.elm
+++ b/web/elm/Views/Services.elm
@@ -2,7 +2,7 @@ module Views.Services exposing (..)
 
 import Components.QuoteBubble exposing (cycleQuoteBackground, quoteBubble)
 import Components.Utils exposing (emptyDiv, outboundLink)
-import Data.UserInfo exposing (isValidEmail)
+import Data.UserInfo exposing (isValidEmail, postCodeToString)
 import Helpers.Styles as Styles exposing (classes)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -11,6 +11,7 @@ import HtmlParser
 import HtmlParser.Util
 import Model exposing (..)
 import Model.Email exposing (..)
+import Model.Postcode exposing (Postcode)
 
 
 services : Model -> Html Msg
@@ -24,7 +25,7 @@ services model =
             , h3 [] [ text "Based on what you've told us, here's the information and support that we think's right for you." ]
             , h3 [] [ text "Shall we email you a copy?" ]
             , a [ href <| "#" ++ emailAnchor ] [ button [ class Styles.buttonClearHover ] [ text "Yes Please" ] ]
-            , div [ class "pb3" ] (List.indexedMap renderService model.top3Services)
+            , div [ class "pb3" ] (List.indexedMap (renderService model.postcode) model.top3Services)
             , div [ class "mw7 center", id emailAnchor ]
                 [ renderEmailForm model
                 , emailSubmitted model
@@ -42,18 +43,33 @@ services model =
             ]
 
 
-renderService : Int -> ServiceData -> Html Msg
-renderService i service =
+renderService : Postcode -> Int -> ServiceData -> Html Msg
+renderService postcode i service =
     let
-        cta =
+        url =
+            handleLocationBasedUrl postcode service
+
+        ctaButton =
             button [ class Styles.buttonClearHover ] [ text service.cta ]
-                |> outboundLink service.url
+
+        cta =
+            outboundLink url ctaButton
     in
         div [ class "mw7 pa4 center" ]
             [ div [ class "mw5 center" ] [ quoteBubble service.title "ph5-ns" (cycleQuoteBackground i) ]
             , div [] <| parseServiceBody service.body
             , cta
             ]
+
+
+handleLocationBasedUrl : Postcode -> ServiceData -> String
+handleLocationBasedUrl postcode serviceData =
+    case serviceData.locationBasedUrl of
+        True ->
+            serviceData.url ++ (postCodeToString postcode)
+
+        False ->
+            serviceData.url
 
 
 parseServiceBody : String -> List (Html Msg)

--- a/web/elm/Views/Services.elm
+++ b/web/elm/Views/Services.elm
@@ -196,7 +196,7 @@ emailSubmitted model =
 surveyLink : Html Msg
 surveyLink =
     a
-        [ href "https://docs.google.com/forms/d/1rrPNT0GtthACdNwFUTbW_QSIb37MXd94SpPcNurK7Rs/viewform?edit_requested=true"
+        [ href "https://goo.gl/forms/Ld8X0fSkdMF5wvlo2"
         , target "_blank"
         ]
         [ button

--- a/web/elm/Views/Services.elm
+++ b/web/elm/Views/Services.elm
@@ -1,7 +1,7 @@
 module Views.Services exposing (..)
 
 import Components.QuoteBubble exposing (cycleQuoteBackground, quoteBubble)
-import Components.Utils exposing (emptyDiv)
+import Components.Utils exposing (emptyDiv, outboundLink)
 import Data.UserInfo exposing (isValidEmail)
 import Helpers.Styles as Styles exposing (classes)
 import Html exposing (..)
@@ -43,12 +43,17 @@ services model =
 
 
 renderService : Int -> ServiceData -> Html Msg
-renderService i s =
-    div [ class "mw7 pa4 center" ]
-        [ div [ class "mw5 center" ] [ quoteBubble s.title "ph5-ns" (cycleQuoteBackground i) ]
-        , div [] <| parseServiceBody s.body
-        , a [ href s.url, target "_blank" ] [ button [ class Styles.buttonClearHover ] [ text s.cta ] ]
-        ]
+renderService i service =
+    let
+        cta =
+            button [ class Styles.buttonClearHover ] [ text service.cta ]
+                |> outboundLink service.url
+    in
+        div [ class "mw7 pa4 center" ]
+            [ div [ class "mw5 center" ] [ quoteBubble service.title "ph5-ns" (cycleQuoteBackground i) ]
+            , div [] <| parseServiceBody service.body
+            , cta
+            ]
 
 
 parseServiceBody : String -> List (Html Msg)
@@ -124,24 +129,29 @@ emailForm model prompt email =
 
 privacyStatement : Model -> Html Msg
 privacyStatement model =
-    p [ class "f6" ]
-        [ input
-            [ type_ "checkbox"
-            , onCheck SetEmailConsent
-            , checked model.emailConsent
-            , class "mr1"
-            ]
-            []
-        , text "We would love to get in touch with you again and hear what you thought about "
-        , i [ class "dark-blue" ] [ text "Parkinson's and Me" ]
-        , text ". If you're happy to be contacted by Parkinson's UK in the future, plase tick this box. To find out more, read our "
-        , a
-            [ href "https://www.parkinsons.org.uk/content/parkinsons-uk-website-terms-and-conditions"
-            , target "_blank"
-            , class "no-underline dark-blue"
-            ]
-            [ text "privacy statement." ]
-        ]
+    case model.emailConsent of
+        False ->
+            p [ class "f6" ]
+                [ input
+                    [ type_ "checkbox"
+                    , onCheck SetEmailConsent
+                    , checked model.emailConsent
+                    , class "mr1"
+                    ]
+                    []
+                , text "We would love to get in touch with you again and hear what you thought about "
+                , i [ class "dark-blue" ] [ text "Parkinson's and Me" ]
+                , text ". If you're happy to be contacted by Parkinson's UK in the future, plase tick this box. To find out more, read our "
+                , a
+                    [ href "https://www.parkinsons.org.uk/content/parkinsons-uk-website-terms-and-conditions"
+                    , target "_blank"
+                    , class "no-underline dark-blue"
+                    ]
+                    [ text "privacy statement." ]
+                ]
+
+        True ->
+            emptyDiv
 
 
 handleSubmitEmail : Model -> Html Msg

--- a/web/elm/Web/QuoteServiceWeightings.elm
+++ b/web/elm/Web/QuoteServiceWeightings.elm
@@ -1,11 +1,11 @@
 module Web.QuoteServiceWeightings exposing (..)
 
+import Data.QuoteServiceWeightings exposing (..)
+import Dict exposing (..)
+import Http exposing (..)
 import Json.Decode as Decode exposing (..)
 import Json.Decode.Pipeline exposing (..)
-import Http exposing (..)
 import Model exposing (..)
-import Dict exposing (..)
-import Data.QuoteServiceWeightings exposing (..)
 
 
 getQuoteServiceWeightings : Cmd Msg
@@ -43,13 +43,18 @@ servicesDecoder =
 
 rawServiceDecoder : Decoder ( ServiceId, ServiceData )
 rawServiceDecoder =
-    decode (\serviceId body title cta url earlyOnset -> ( serviceId, ServiceData title body cta url earlyOnset ))
-        |> required "id" int
-        |> required "body" string
-        |> required "title" string
-        |> required "cta" string
-        |> required "url" string
-        |> required "early_onset" bool
+    let
+        service a b c d e f i =
+            ( i, ServiceData a b c d e f )
+    in
+        decode service
+            |> required "title" string
+            |> required "body" string
+            |> required "cta" string
+            |> required "url" string
+            |> required "early_onset" bool
+            |> required "location_based_url" bool
+            |> required "id" int
 
 
 weightingDecoder : Decoder Weightings

--- a/web/models/service.ex
+++ b/web/models/service.ex
@@ -8,10 +8,11 @@ defmodule ParkinsonsAndMe.Service do
     field :cta, :string
     field :url, :string
     field :early_onset, :boolean
+    field :location_based_url, :boolean
   end
 
-  @valid_fields [:title, :body, :cta, :url, :early_onset]
-  @required_fields [:title, :body, :cta, :url, :early_onset]
+  @valid_fields [:title, :body, :cta, :url, :early_onset, :location_based_url]
+  @required_fields [:title, :body, :cta, :url, :early_onset, :location_based_url]
 
   def changeset(struct, params \\ %{}) do
     struct

--- a/web/templates/email/results.html.eex
+++ b/web/templates/email/results.html.eex
@@ -15,7 +15,7 @@
     <%= for x <- @top3services do %>
       <div class="ma2 pa2">
         <h2 class="ma0"> <%= x.title %> </h2>
-        <p> <%= x.body %> </p>
+        <p> <%= raw(x.body) %> </p>
         <a
         href="<%= x.cta %>",
         class="<%= button_style %>"

--- a/web/views/service_view.ex
+++ b/web/views/service_view.ex
@@ -7,7 +7,8 @@ defmodule ParkinsonsAndMe.ServiceView do
       body: service.body,
       cta: service.cta,
       url: service.url,
-      early_onset: service.early_onset}
+      early_onset: service.early_onset,
+      location_based_url: service.location_based_url}
   end
 
   def order_services(services) do


### PR DESCRIPTION
+ services marked with a `location_based_url` field will have the users' postcode appended to the query param for the service cta
+ unescape html strings for email template (the service body)
+ track outbound cta links
